### PR TITLE
Y combinator refactor + a few combinators docs improvement

### DIFF
--- a/SwiftLand/Combinators.swift
+++ b/SwiftLand/Combinators.swift
@@ -8,102 +8,202 @@
 
 import Foundation
 
-//To Mock a Mockingbird by Smullyan
-//Bird monickered combinators
+// MARK: Combinators: Functions
 
+/*~
+ * ---
+ * name           : Identity
+ * #              : I
+ * category       : Combinators
+ * description    : Returns its argument.
+ * type signature : a → a
+ *
+ */
 
-/// I-combinator The identity function; always returns its argument.
 public func id<T>(_ x: T) -> T {
     return x
 }
 
+/*~
+ * ---
+ * name           : Constant
+ * #              : K
+ * category       : Combinators
+ * description    : Takes two values and returns the first.
+ * type signature : a → b → a
+ *
+ */
 
-/// K-combinator : constant combinator ignores its second argument and always returns its first argument.
 public func const<A, B>(_ x : A) -> (B) -> A {
     return { (_) in
         return x
     }
 }
 
+/*~
+ * ---
+ * name           : Substitution
+ * #              : S
+ * category       : Combinators
+ * description    : Takes a curried binary function, an unary function,
+                    and a value, and returns the result of applying 
+                    the binary function to:
+                    - the value; and
+                    - the result of applying the unary function to the value.
+ * type signature : (a → b → c) → (a → b) → a → c
+ *
+ */
 
-/// S-combinator Applies the second function to a value, then applies the first function to a value and the
-/// result of the previous function application.
 public func substitute<R, A, B>(_ f : @escaping (R) -> (A) -> B) -> ( @escaping (R) -> A) -> (R) -> B {
     return { g in { x in f(x)(g(x)) } }
 }
 
+/*~
+ * ---
+ * name           : Fixed-Point
+ * #              : Y
+ * category       : Combinators
+ * description    : Takes a functional as input, and it returns the (unique)
+                    fixed point of that functional as its output. A 
+                    functional is a function that takes a function for its input.
+ * type signature : (a → a) → a
+ *
+ */
 
-/// Y-combinator
-/// Returns the least fixed point of the function returned by `f`.
-///
-/// This is useful for e.g. making recursive closures without using the two-step assignment dance.
-///
-/// \param f  - A function which takes a parameter function, and returns a result function. The result function may recur by calling the parameter function.
-///
-/// \return  A recursive function.
 public func fix<T, U>(_ f: @escaping ((T) -> U) -> (T) -> U) -> (T) -> U {
     return { f(fix(f))($0) }
 }
 
 
-///C-combinator (2,3,4-arity)
-/// Returns a binary function which calls `f` with its arguments reversed.
-///
-/// I.e. `flip(f)(x, y)` is equivalent to `f(y, x)`.
+/*~
+ * ---
+ * name           : Flip (2-arity)
+ * #              : C
+ * category       : Combinators
+ * description    : Takes a curried binary function and two values, and
+                    returns the result of applying the function to the 
+                    values in reverse order.
+ * type signature : (a → b → c) → b → a → c
+ *
+ */
+
 public func flip<T, U, V>(_ f: @escaping (T, U) -> V) -> (U, T) -> V {
     return { f($1, $0) }
 }
-/// Returns a ternary function which calls `f` with its arguments reversed.
-///
-/// I.e. `flip(f)(x, y, z)` is equivalent to `f(z, y, x)`.
+
+// Flip (3-arity)
+
 public func flip<T, U, V, W>(_ f: @escaping (T, U, V) -> W) -> (V, U, T) -> W {
     return { f($2, $1, $0) }
 }
-/// Returns a quaternary function which calls `f` with its arguments reversed.
-///
-/// I.e. `flip(f)(w, x, y, z)` is equivalent to `f(z, y, x, w)`.
+
+// Flip (4-arity)
+
 public func flip<T, U, V, W, X>(_ f: @escaping (T, U, V, W) -> X) -> (W, V, U, T) -> X {
     return { f($3, $2, $1, $0) }
 }
 
+/*~
+ * ---
+ * name           : Apply
+ * #              : A
+ * category       : Combinators
+ * description    : Takes a function and a value, and returns the result
+                    of applying the function to the value.
+ * type signature : (a → b) → a → b
+ *
+ */
+
+public func § <A,B> (f: @escaping (A) -> B, a: A) -> B {
+    return f(a)
+}
+
+/*~
+ * ---
+ * name           : Compose
+ * #              : B
+ * category       : Combinators
+ * description    : Takes two functions and a value, and returns the
+                    result of applying the first function to the result 
+                    of applying the second to the value.
+ * type signature : (b → c) → (a → b) → a → c
+ *
+ */
+
+public func >>> <A, B, C> (f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
+    return { x in f(g(x)) }
+}
+
+
+/*~
+ * ---
+ * name           : Duplication
+ * #              : W
+ * category       : Combinators
+ * description    : Behaves as an elementary duplicator
+ * type signature : (a → a → b) → a → b
+ *
+ */
+
+public func duplicate <A, B> (f: @escaping (A) -> B, a: A) -> (A, A) -> B {
+    return { x in f(a) }
+}
+
+/*~
+ * ---
+ * name           : Psi
+ * #              : P
+ * category       : Combinators
+ * description    : Applies the function on its right to both its arguments, 
+                    then applies the function on its left to the result of 
+                    both prior applications.
+ * type signature : (b → b → c) → (a → b) → a → a → c
+ *
+ */
+
+public func on<A, B, C>(_ o : @escaping (B) -> (B) -> C) -> ( @escaping (A) -> B) -> (A) -> (A) -> C {
+    return { f in { x in { y in o(f(x))(f(y)) } } }
+}
+
+// MARK: Combinators: Operators
+
+/*~
+ * ---
+ * name           : Apply
+ * #              : A
+ * category       : Combinators: Operators
+ * associativity  : Right
+ * description    : Takes a function and a value, and returns the result
+                    of applying the function to the value.
+ * type signature : (a → b) → a → b
+ *
+ */
 
 precedencegroup RightApplyPrecedence {
     associativity: right
     higherThan: AssignmentPrecedence
     lowerThan: TernaryPrecedence
 }
+
 infix operator § : RightApplyPrecedence
 
-///A-combinator - apply / applicator (also called i-star)
-//func § <A, B>(A -> B, A) -> B
-func § <A,B> (f: @escaping (A) -> B, a: A) -> B {
-    return f(a)
-}
+/*~
+ * ---
+ * name           : Compose
+ * #              : B
+ * category       : Combinators: Operators
+ * associativity  : Right
+ * description    : Takes two functions and a value, and returns the
+                    result of applying the first function to the result
+                    of applying the second to the value.
+ * type signature : (b → c) → (a → b) → a → c
+ *
+ */
 
 precedencegroup CompositionPrecedence {
     associativity: right
     higherThan: BitwiseShiftPrecedence
 }
+
 infix operator >>> : CompositionPrecedence
-
-///B-combinator (bluebird) or compose
-public func >>> <A, B, C> (f: @escaping (B) -> C, g: @escaping (A) -> B) -> (A) -> C {
-    return { x in f(g(x)) }
-}
-
-
-///W-combinator (elementary duplicator)
-public func duplicate <A, B> (f: @escaping (A) -> B, a: A) -> (A, A) -> B {
-    return { x in f(a) }
-}
-
-
-///Psi-combinator
-///Applies the function on its right to both its arguments, then applies the function on its
-/// left to the result of both prior applications.
-///
-///    (+) |*| f = { x in { y in f(x) + f(y) } }
-public func on<A, B, C>(_ o : @escaping (B) -> (B) -> C) -> ( @escaping (A) -> B) -> (A) -> (A) -> C {
-    return { f in { x in { y in o(f(x))(f(y)) } } }
-}
 

--- a/SwiftLand/Combinators.swift
+++ b/SwiftLand/Combinators.swift
@@ -8,6 +8,12 @@
 
 import Foundation
 
+// MARK: Combinators: Helpers
+
+struct RecursiveFunction<F> {
+    let o: (RecursiveFunction<F>) -> F
+}
+
 // MARK: Combinators: Functions
 
 /*~
@@ -70,8 +76,14 @@ public func substitute<R, A, B>(_ f : @escaping (R) -> (A) -> B) -> ( @escaping 
  *
  */
 
-public func fix<T, U>(_ f: @escaping ((T) -> U) -> (T) -> U) -> (T) -> U {
-    return { f(fix(f))($0) }
+public func fix<T, U>(f: @escaping ((T) -> U) -> (T) -> U) -> (T) -> U {
+    
+    let helperFunction = RecursiveFunction<(T) -> U> { w in
+        f {
+            w.o(w)($0)
+        }
+    }
+    return helperFunction.o(helperFunction)
 }
 
 


### PR DESCRIPTION
Hey, I just loved your project; it was a pleasure to me–being a JS developer who's engaged in learning more about *Swift* and *lambda calculus*–to find all combinators from [fantasy land](https://github.com/fantasyland/fantasy-combinators#general) implemented in *Swift*.

But I was wondering if it could be improved in two aspects:

### Documentation

There was no standard for combinators documentation–actually, they were all well documented; this would be really a simple improvement–so I thought about something like this for each combinator implementation:

```swift 
/*~
 * ---
 * name           : Identity
 * #              : I
 * category       : Combinators
 * description    : Returns its argument.
 * type signature : a → a
 *
 */

public func id<T>(_ x: T) -> T {
    return x
}
```

### *Y Combinator* 

The current function which implements the *Y Combinator* (`fix`) actually finds the fixed point of a functional, and we could use it to eliminate recursion. But, in the way it is defined, the function still calls itself recursively, so we haven't really eliminated recursion yet. We've just moved it all into the function `fix`. 

Maybe using a helper type like this:

```swift
struct RecursiveFunction<F> {
    let o: (RecursiveFunction<F>) -> F
}
```

we can eliminate the recursive call inside the Y combinator, which, with a couple more transformations gets us to a very close result–but which makes no reference to `fix`:

```swift
public func fix<T, U>(f: @escaping ((T) -> U) -> (T) -> U) -> (T) -> U {
    
    let helperFunction = RecursiveFunction<(T) -> U> { w in
        f {
            w.o(w)($0)
        }
    }
    return helperFunction.o(helperFunction)
}
```

> The results should be the very same since your implementation already behaves in the way it should. Again, this *PR* just proposes very simple possible improvements 😄 